### PR TITLE
Added github.com/libp2p/go-utp-transport

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -157,3 +157,6 @@
 [submodule "go-eventbus"]
 	path = go-eventbus
 	url = git@github.com:libp2p/go-eventbus.git
+[submodule "go-utp-transport"]
+	path = go-utp-transport
+	url = git@github.com:libp2p/go-utp-transport.git


### PR DESCRIPTION
I'm upgrading the utp transport to consolidated types, so I'm using the workspace with it.
Blocked: libp2p/go-utp-transport#5.