### PR TITLE
Fixing multiformats repos.

### DIFF
--- a/workspace.sh
+++ b/workspace.sh
@@ -16,9 +16,7 @@ while IFS='' read -r line; do mods+=("$line"); done < \
 ##   It expect the origin to be `git@github.com:<orgname>/<repo-name>.git` (ssh format).
 get_repo() {
 	local mod="${1}"
-	cd "$mod"
-	git remote get-url origin | cut -d':' -f2 | cut -d'.' -f1
-	cd ..
+	git -C "$mod" remote get-url origin | cut -d':' -f2 | cut -d'.' -f1
 }
 
 ## Edits a module gomod. Args:


### PR DESCRIPTION
Before multiformats replace was wrongly written (ex: github.com/libp2p/go-multistream).
Now this is correctly done (github.com/multiformats/go-multistream).

That also open the ability to add other repo (ipfs, filecoin, ...).
But the origin of submoduble **MUST** be ssh type, not https.